### PR TITLE
Fix Slack webhook env name

### DIFF
--- a/.github/workflows/cronjob.yml
+++ b/.github/workflows/cronjob.yml
@@ -43,7 +43,7 @@ jobs:
       - name: run
         run: ./main
         env:
-          SLACK_WEBHOOK_ULR_5MIN: ${{ secrets.slack_webhook_url_5min }}
+          SLACK_WEBHOOK_URL_5MIN: ${{ secrets.slack_webhook_url_5min }}
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: steps.download_2.outcome == 'failure'
         with:

--- a/main/main.go
+++ b/main/main.go
@@ -10,7 +10,7 @@ import (
 
 func readArgument() actiontype.Argument {
 	return actiontype.NewArgument(
-		os.Getenv("SLACK_WEBHOOK_ULR_5MIN"),
+		os.Getenv("SLACK_WEBHOOK_URL_5MIN"),
 	)
 }
 
@@ -18,7 +18,7 @@ func main() {
 	args := readArgument()
 
 	if err := slack5min.Run(args.GetSlackWebhookURL5min()); err != nil {
-		fmt.Errorf("error: %v", err)
+		fmt.Printf("error: %v\n", err)
 	}
 
 	fmt.Println("Hello golang!")


### PR DESCRIPTION
## Summary
- fix environment variable name for Slack webhook
- log Slack errors instead of discarding them

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6840abf94f5483228f84f9c80ab6e64b